### PR TITLE
Replace absolut applications link by relative

### DIFF
--- a/module/DeployAgent/src/Task/TaskManager.php
+++ b/module/DeployAgent/src/Task/TaskManager.php
@@ -290,10 +290,15 @@ class TaskManager implements ListenerAggregateInterface, LoggerAwareInterface
         $message = 'Starting ' . $application->getName() . ' (' . $build . ')';
         $this->getLogger()->info($message);
 
+        $pwd = getcwd();
+        chdir($application->getPath() . DIRECTORY_SEPARATOR);
+
         symlink(
-            $application->getPath() . DIRECTORY_SEPARATOR . $build,
-            $application->getPath() . DIRECTORY_SEPARATOR . 'current'
+            $build,
+            'current'
         );
+
+        chdir($pwd);
 
         $application->getEventManager()->trigger($application::EVENT_AFTER_ACTIVATE);
 


### PR DESCRIPTION
Replace application symlinks by absolute path for avoid bug path under Jail Chroot.