### PR TITLE
use tar command on non-windows systems

### DIFF
--- a/module/DeployAgent/src/Resource/Archive/Extractor/TarGzExtractor.php
+++ b/module/DeployAgent/src/Resource/Archive/Extractor/TarGzExtractor.php
@@ -37,7 +37,6 @@ class TarGzExtractor implements ExtractorInterface
             unlink(str_replace('.tar.gz', '.tar', $archive->getPathname()));
         } else {
             exec('tar xzf ' . $archive->getPathname() . ' -C ' . $destination->getPathname());
-            //unlink($archive->getPathname());
         }
 
         return true;

--- a/module/DeployAgent/src/Resource/Archive/Extractor/TarGzExtractor.php
+++ b/module/DeployAgent/src/Resource/Archive/Extractor/TarGzExtractor.php
@@ -37,6 +37,10 @@ class TarGzExtractor implements ExtractorInterface
             unlink(str_replace('.tar.gz', '.tar', $archive->getPathname()));
         } else {
             exec('tar xzf ' . $archive->getPathname() . ' -C ' . $destination->getPathname());
+            
+            var_dump('tar xzf ' . $archive->getPathname() . ' -C ' . $destination->getPathname());
+            var_dump(glob($destination->getPathname() . '/*'));
+            
             unlink($archive->getPathname());
         }
 

--- a/module/DeployAgent/src/Resource/Archive/Extractor/TarGzExtractor.php
+++ b/module/DeployAgent/src/Resource/Archive/Extractor/TarGzExtractor.php
@@ -29,20 +29,16 @@ class TarGzExtractor implements ExtractorInterface
      */
     public function extract(\SplFileInfo $archive, \SplFileInfo $destination)
     {
-        if (preg_match('/^win/i', PHP_OS)) {
+        //if (preg_match('/^win/i', PHP_OS)) {
             $targz = new \PharData($archive->getPathname());
             /** @var \PharData $tar */
             $tar = $targz->decompress();
             $tar->extractTo($destination->getPathname());
             unlink(str_replace('.tar.gz', '.tar', $archive->getPathname()));
-        } else {
+        /*} else {
             exec('tar xzf ' . $archive->getPathname() . ' -C ' . $destination->getPathname());
-            
-            var_dump('tar xzf ' . $archive->getPathname() . ' -C ' . $destination->getPathname());
-            var_dump(glob($destination->getPathname() . '/*'));
-            
             unlink($archive->getPathname());
-        }
+        }*/
 
         return true;
     }

--- a/module/DeployAgent/src/Resource/Archive/Extractor/TarGzExtractor.php
+++ b/module/DeployAgent/src/Resource/Archive/Extractor/TarGzExtractor.php
@@ -37,7 +37,7 @@ class TarGzExtractor implements ExtractorInterface
             unlink(str_replace('.tar.gz', '.tar', $archive->getPathname()));
         } else {
             exec('tar xzf ' . $archive->getPathname() . ' -C ' . $destination->getPathname());
-            unlink($archive->getPathname());
+            //unlink($archive->getPathname());
         }
 
         return true;

--- a/module/DeployAgent/src/Resource/Archive/Extractor/TarGzExtractor.php
+++ b/module/DeployAgent/src/Resource/Archive/Extractor/TarGzExtractor.php
@@ -29,16 +29,16 @@ class TarGzExtractor implements ExtractorInterface
      */
     public function extract(\SplFileInfo $archive, \SplFileInfo $destination)
     {
-        //if (preg_match('/^win/i', PHP_OS)) {
+        if (preg_match('/^win/i', PHP_OS)) {
             $targz = new \PharData($archive->getPathname());
             /** @var \PharData $tar */
             $tar = $targz->decompress();
             $tar->extractTo($destination->getPathname());
             unlink(str_replace('.tar.gz', '.tar', $archive->getPathname()));
-        /*} else {
+        } else {
             exec('tar xzf ' . $archive->getPathname() . ' -C ' . $destination->getPathname());
             unlink($archive->getPathname());
-        }*/
+        }
 
         return true;
     }

--- a/module/DeployAgent/src/Resource/Archive/Extractor/TarGzExtractor.php
+++ b/module/DeployAgent/src/Resource/Archive/Extractor/TarGzExtractor.php
@@ -29,11 +29,17 @@ class TarGzExtractor implements ExtractorInterface
      */
     public function extract(\SplFileInfo $archive, \SplFileInfo $destination)
     {
-        $targz = new \PharData($archive->getPathname());
-        /** @var \PharData $tar */
-        $tar = $targz->decompress();
-        $tar->extractTo($destination->getPathname());
-        unlink(str_replace('.tar.gz', '.tar', $archive->getPathname()));
+        if (preg_match('/^win/i', PHP_OS)) {
+            $targz = new \PharData($archive->getPathname());
+            /** @var \PharData $tar */
+            $tar = $targz->decompress();
+            $tar->extractTo($destination->getPathname());
+            unlink(str_replace('.tar.gz', '.tar', $archive->getPathname()));
+        } else {
+            exec('tar xzf ' . $archive->getPathname() . ' -C ' . $destination->getPathname());
+            unlink($archive->getPathname());
+        }
+
         return true;
     }
 


### PR DESCRIPTION
on non-windows systems, use the tar command to extract the package; because PharData doesn't keep symlinks when decompressing.